### PR TITLE
Add glowing external profile links

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,45 @@
         </div>
       </section>
     </main>
+    <div class="social-links" role="navigation" aria-label="External profiles">
+      <a
+        class="social-link"
+        href="https://github.com/AE-BASOL"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open GitHub profile"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.71c-2.78.6-3.37-1.34-3.37-1.34-.46-1.17-1.12-1.48-1.12-1.48-.92-.63.07-.62.07-.62 1.02.07 1.55 1.05 1.55 1.05.9 1.54 2.36 1.1 2.94.84a2.15 2.15 0 0 1 .64-1.35c-2.22-.25-4.56-1.12-4.56-4.98a3.9 3.9 0 0 1 1.05-2.71 3.6 3.6 0 0 1 .1-2.67s.84-.27 2.75 1.03a9.47 9.47 0 0 1 5 0c1.91-1.3 2.75-1.03 2.75-1.03.55 1.36.2 2.36.1 2.67a3.9 3.9 0 0 1 1.05 2.71c0 3.88-2.34 4.73-4.58 4.98a2.41 2.41 0 0 1 .69 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"
+          />
+        </svg>
+      </a>
+      <a
+        class="social-link"
+        href="https://www.linkedin.com/in/aebasol/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open LinkedIn profile"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Zm-9.53 15H6.47V9.5h2.99ZM7.99 8.3A1.73 1.73 0 1 1 9.7 6.57 1.72 1.72 0 0 1 7.99 8.3Zm10.04 9.7h-2.99v-3.94c0-.94-.02-2.15-1.31-2.15-1.31 0-1.51 1.02-1.51 2.08V18H9.22V9.5h2.87v1.16h.04a3.15 3.15 0 0 1 2.84-1.56c3.04 0 3.6 2 3.6 4.59Z"
+          />
+        </svg>
+      </a>
+      <a
+        class="social-link"
+        href="mailto:ahmetefe.basol@gmail.com"
+        aria-label="Send an email to Ahmet Efe Başol"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M4.5 5h15a1.5 1.5 0 0 1 1.5 1.5v11a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 17.5v-11A1.5 1.5 0 0 1 4.5 5Zm.3 2 6.93 5.18a.5.5 0 0 0 .54 0L19.2 7Zm14.7 1.35-5.75 4.29 5.75 4.29Zm-1.06 8.65-5.64-4.2-.7.53a1.5 1.5 0 0 1-1.8 0l-.7-.53-5.64 4.2Z"
+          />
+        </svg>
+      </a>
+    </div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/style.css
+++ b/src/style.css
@@ -529,6 +529,105 @@ body {
   pointer-events: none;
 }
 
+.social-links {
+  position: fixed;
+  bottom: clamp(1.6rem, 5vh, 3rem);
+  left: 50%;
+  transform: translate(-50%, 0);
+  display: inline-flex;
+  align-items: center;
+  gap: 1.1rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.52));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  backdrop-filter: blur(14px) saturate(140%);
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.45);
+  z-index: 6;
+  opacity: 0;
+  animation: social-fade-in 0.8s ease 0.35s forwards;
+}
+
+.social-links::before {
+  content: 'Connect';
+  position: absolute;
+  bottom: calc(100% + 0.6rem);
+  left: 50%;
+  transform: translate(-50%, 6px);
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.8);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.45);
+}
+
+.social-links:hover::before,
+.social-links:focus-within::before {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.social-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(148, 163, 184, 0.35), rgba(30, 64, 175, 0.2));
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28), 0 8px 24px rgba(15, 23, 42, 0.45);
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.68;
+  transition: opacity 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.social-link svg {
+  width: 1.32rem;
+  height: 1.32rem;
+  fill: rgba(226, 232, 240, 0.9);
+  transition: filter 0.25s ease, fill 0.25s ease;
+}
+
+.social-link:hover,
+.social-link:focus-visible {
+  opacity: 1;
+  transform: translateY(-2px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 14px 30px rgba(56, 189, 248, 0.35);
+  border-color: rgba(125, 211, 252, 0.7);
+  background: radial-gradient(circle at 30% 30%, rgba(96, 165, 250, 0.45), rgba(30, 64, 175, 0.25));
+  outline: none;
+}
+
+.social-link:hover svg,
+.social-link:focus-visible svg {
+  fill: #f8fafc;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.6));
+}
+
+.social-link:focus-visible {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 14px 32px rgba(56, 189, 248, 0.45);
+}
+
+@keyframes social-fade-in {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 16px);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
 @media (max-width: 900px) {
   body {
     padding: clamp(6.5rem, 24vh, 10rem) clamp(1.1rem, 5vw, 2.6rem) clamp(3rem, 14vh, 5rem);
@@ -553,5 +652,16 @@ body {
 
   .target-link {
     padding: 0.7rem 1.35rem;
+  }
+
+  .social-links {
+    bottom: clamp(1.1rem, 7vh, 2.2rem);
+    gap: 0.85rem;
+    padding: 0.35rem 0.6rem;
+  }
+
+  .social-link {
+    width: 2.4rem;
+    height: 2.4rem;
   }
 }


### PR DESCRIPTION
## Summary
- add a fixed external profile navigation bar with GitHub, LinkedIn, and email icons beneath the playfield
- style the icons to match the dark glass aesthetic with hover glow, tooltip, and fade-in animation while keeping them visible at all times
- tweak responsive sizing so the controls remain comfortable on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690b618ca82083249ba48e31ef010dfa